### PR TITLE
Fix: Prevent TOTAL from showing Infinity for large directories

### DIFF
--- a/dirsize
+++ b/dirsize
@@ -51,5 +51,10 @@ fi
 } | sort -h
 
 # Print final total of all listed items
-total=$(du -shc "${items[@]}" 2>/dev/null | tail -n1 | awk '{print $1}')
-echo "TOTAL: $total"
+total_bytes=$(du -scb "${items[@]}" 2>/dev/null | tail -n1 | awk '{print $1}')
+if [[ -n "$total_bytes" && "$total_bytes" =~ ^[0-9]+$ ]]; then
+  total_human=$(numfmt --to=iec-i --suffix=B --format='%9.2f' "$total_bytes")
+else
+  total_human="0.00B" # Default value if total_bytes is empty or not a number
+fi
+echo "TOTAL: $total_human"


### PR DESCRIPTION
The script previously used `du -shc` to calculate the total size. For very large directories, `du -shc` can output 'Infinity', which was then reflected in the script's output.

This commit changes the total calculation to:
1. Use `du -scb` to get the total size in bytes. This provides a raw numerical value that won't be 'Infinity'.
2. Use `numfmt --to=iec-i --suffix=B --format='%9.2f'` to convert the byte total into a human-readable format (e.g., KiB, MiB, GiB). A check is included to handle cases where the byte total might be empty or non-numeric, defaulting to "0.00B".

This ensures that the script always displays a proper numerical total, even for very large directory sizes, and improves the accuracy of the human-readable format by using IEC standard units.